### PR TITLE
Added support for .aab (Android App Bundle)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+const aab = 'aab'
+const apk = 'apk'
+const fileTypes = [aab, apk]
 
 const argv = require('yargs')
   .usage('Usage: $0 [options]')
@@ -13,16 +16,22 @@ const argv = require('yargs')
     describe: 'Service account file path',
     demand: true
   })
-  .option('a', {
-    alias: 'apk',
+  .option('p', {
+    alias: 'filePath',
     type: 'string',
-    describe: 'Release apk file path',
+    describe: 'Release apk/aab file path',
     demand: true
   })
-  .option('p', {
-    alias: 'packageName',
+  .option('n', {
+    alias: 'name',
     type: 'string',
-    describe: 'Enter package name',
+    describe: 'Enter file name',
+    demand: true
+  })
+  .option('f', {
+    alias: 'fileType',
+    choices: fileTypes,
+    describe: 'Choose file type',
     demand: true
   })
   .help('h').argv;
@@ -30,13 +39,22 @@ const argv = require('yargs')
 const options = {
   track: argv.track,
   keyFilePath: argv.key,
-  apkFilePath: argv.apk,
-  packageName: argv.packageName
+  filePath: argv.filePath,
+  packageName: argv.packageName,
 };
+
+const fileType = argv.fileType
 
 const playstore = require('./index');
 
-playstore.publish(options).catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+if (fileType === aab) {
+  playstore.publishAAB(options).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+} else if (fileType == apk) {
+  playstore.publishAPK(options).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/cli.js
+++ b/cli.js
@@ -3,6 +3,10 @@ const aab = 'aab'
 const apk = 'apk'
 const fileTypes = [aab, apk]
 
+const standard = "standard"
+const appShare = "appShare"
+const uploadTypes = [standard, appShare]
+
 const argv = require('yargs')
   .usage('Usage: $0 [options]')
   .option('t', {
@@ -34,6 +38,12 @@ const argv = require('yargs')
     describe: 'Choose file type',
     demand: true
   })
+  .option('u', {
+    alias: 'uploadType',
+    choices: uploadTypes,
+    describe: 'Choose upload type',
+    default: standard
+  })
   .help('h').argv;
 
 const options = {
@@ -43,9 +53,25 @@ const options = {
   packageName: argv.packageName,
 };
 
+const shareOptions = {
+  keyFilePath: argv.key,
+  filePath: argv.filePath,
+  packageName: argv.packageName,
+}
+
 const fileType = argv.fileType
 
+const uploadType = argv.uploadType
+
 const playstore = require('./index');
+
+if (uploadType == appShare) {
+  playstore.shareAAB(shareOptions).catch(err => {
+    console.error(err)
+  }).then(() => {
+    process.exit(1);
+  })
+}
 
 if (fileType === aab) {
   playstore.publishAAB(options).catch(err => {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ const getAuth = keyFilePath =>
 
 upload = async ({ packageName, editId, file, fileType, size, token }) => {
   const uploadUrl = 'https://www.googleapis.com/upload/androidpublisher/v3/applications';
-  console.log(`about to upload`)
 
   return await axios.post(
     `${uploadUrl}/${packageName}/edits/${editId}/${fileType}?uploadType=media&access_token=${token}`,
@@ -35,12 +34,9 @@ upload = async ({ packageName, editId, file, fileType, size, token }) => {
 
 publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
   try {
-    console.log(`keyFilePath: ${keyFilePath}`)
     const auth = await getAuth(keyFilePath);
-    console.log(`auth: ${JSON.stringify(auth)}`)
 
     const { token } = await auth.getAccessToken();
-    console.log(`token: ${JSON.stringify(token.length)}`)
 
     const baseUrl =
       'https://www.googleapis.com/androidpublisher/v3/applications';
@@ -55,7 +51,7 @@ publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
     const file = await readFilePromise(filePath);
     const { size } = fs.statSync(filePath);
 
-    const uploadRes = await upload(packageName, editId, file, fileType, size, token)
+    const uploadRes = await upload({packageName, editId, file, fileType, size, token})
     const { versionCode } = uploadRes.data;
 
     // set track

--- a/index.js
+++ b/index.js
@@ -93,26 +93,35 @@ publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
 };
 
 const shareAAB = async ({ keyFilePath, packageName, file }) => {
-  const auth = await getAuth(keyFilePath);
+  try {
+    const auth = await getAuth(keyFilePath);
 
-  const { token } = await auth.getAccessToken();
+    const { token } = await auth.getAccessToken();
 
-  const url = `${baseUploadURL}/internalappsharing/${packageName}/artifacts/bundle`
+    const url = `${baseUploadURL}/internalappsharing/${packageName}/artifacts/bundle`
 
-  const file = await readFilePromise(filePath);
-  const { size } = fs.statSync(filePath);
+    const file = await readFilePromise(filePath);
+    const { size } = fs.statSync(filePath);
 
-  return await axios.post(url, file, {
-    headers: {
-      Connection: 'keep-alive',
-      'accept-encoding': 'gzip, deflate',
-      Accept: '*/*',
-      'Content-Type': 'application/octet-stream',
-      Authorization: token
-    },
-    maxContentLength: size * 1000,
-    maxBodyLength: size * 1000
-  });
+    const res = await axios.post(url, file, {
+      headers: {
+        Connection: 'keep-alive',
+        'accept-encoding': 'gzip, deflate',
+        Accept: '*/*',
+        'Content-Type': 'application/octet-stream',
+        Authorization: token
+      },
+      maxContentLength: size * 1000,
+      maxBodyLength: size * 1000
+    });
+    if (res.data.downloadUrl) {
+      console.log(`Internal App Sharing Download URL: ${res.data.downloadUrl}`)
+    } else {
+      console.log("Error retrieving Internal App Share URL")
+    }
+  } catch (e) {
+    console.log("Error uploading to internal app share - :", e);
+  }
 }
 
 exports.publishAPK = async ({ keyFilePath, packageName, track, filePath }) => {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const util = require('util');
 const readFilePromise = util.promisify(fs.readFile);
 
-const getAuth = ({ keyFilePath }) =>
+const getAuth = keyFilePath =>
   google.auth.getClient({
     keyFile: keyFilePath,
     scopes: ['https://www.googleapis.com/auth/androidpublisher']
@@ -13,6 +13,7 @@ const getAuth = ({ keyFilePath }) =>
 
 upload = async ({ packageName, editId, file, fileType, size, token }) => {
   const uploadUrl = 'https://www.googleapis.com/upload/androidpublisher/v3/applications';
+  console.log(`about to upload`)
 
   return await axios.post(
     `${uploadUrl}/${packageName}/edits/${editId}/${fileType}?uploadType=media&access_token=${token}`,
@@ -34,8 +35,12 @@ upload = async ({ packageName, editId, file, fileType, size, token }) => {
 
 publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
   try {
-    const auth = await getAuth({ keyFilePath });
+    console.log(`keyFilePath: ${keyFilePath}`)
+    const auth = await getAuth(keyFilePath);
+    console.log(`auth: ${JSON.stringify(auth)}`)
+
     const { token } = await auth.getAccessToken();
+    console.log(`token: ${JSON.stringify(token.length)}`)
 
     const baseUrl =
       'https://www.googleapis.com/androidpublisher/v3/applications';

--- a/index.js
+++ b/index.js
@@ -34,10 +34,7 @@ upload = async ({ packageName, editId, file, fileType, size, token }) => {
 
 publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
   try {
-    console.log('get auth call')
-    console.log(`keyFilePath: ${keyFilePath}`)
     const auth = await getAuth({ keyFilePath });
-    console.log('gettoken')
     const { token } = await auth.getAccessToken();
 
     const baseUrl =
@@ -80,15 +77,14 @@ publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
       published: true
     };
   } catch (e) {
-    console.log(`catchblock trace: ${e.stack}`)
     throw e
   }
 };
 
 exports.publishAPK = async ({ keyFilePath, packageName, track, filePath }) => {
-  return await publish(keyFilePath, packageName, track, filePath, "apks")
+  return await publish({ keyFilePath: keyFilePath, packageName: packageName, track: track, filePath: filePath, fileType: "apks" })
 }
 
 exports.publishAAB = async ({ keyFilePath, packageName, track, filePath }) => {
-  return await publish(keyFilePath, packageName, track, filePath, "bundles")
+  return await publish({ keyFilePath: keyFilePath, packageName: packageName, track: track, filePath: filePath, fileType: "bundles" })
 }

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
   }
 };
 
-const shareAAB = async ({ keyFilePath, packageName, file }) => {
+const shareAAB = async ({ keyFilePath, packageName, filePath }) => {
   try {
     const auth = await getAuth(keyFilePath);
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,10 @@ upload = async ({ packageName, editId, file, fileType, size, token }) => {
 
 publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
   try {
+    console.log('get auth call')
+    console.log(`keyFilePath: ${keyFilePath}`)
     const auth = await getAuth({ keyFilePath });
+    console.log('gettoken')
     const { token } = await auth.getAccessToken();
 
     const baseUrl =
@@ -77,6 +80,7 @@ publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
       published: true
     };
   } catch (e) {
+    console.log(`catchblock trace: ${e.stack}`)
     throw e
   }
 };

--- a/index.js
+++ b/index.js
@@ -11,15 +11,35 @@ const getAuth = ({ keyFilePath }) =>
     scopes: ['https://www.googleapis.com/auth/androidpublisher']
   });
 
-exports.publish = async ({ keyFilePath, packageName, track, apkFilePath }) => {
+upload = async ({ packageName, editId, file, fileType, size, token }) => {
+  const uploadUrl = 'https://www.googleapis.com/upload/androidpublisher/v3/applications';
+
+  return await axios.post(
+    `${uploadUrl}/${packageName}/edits/${editId}/${fileType}?uploadType=media&access_token=${token}`,
+    file,
+    {
+      headers: {
+        Connection: 'keep-alive',
+        'accept-encoding': 'gzip, deflate',
+        Accept: '*/*',
+        'Content-Type': 'application/vnd.android.package-archive',
+        Authorization: token
+      },
+      maxContentLength: size * 1000,
+      maxBodyLength: size * 1000
+    }
+  );
+
+}
+
+publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
   try {
     const auth = await getAuth({ keyFilePath });
     const { token } = await auth.getAccessToken();
 
     const baseUrl =
       'https://www.googleapis.com/androidpublisher/v3/applications';
-    const uploadUrl =
-      'https://www.googleapis.com/upload/androidpublisher/v3/applications';
+
     // create edit
     const { data: editRes } = await axios.post(
       `${baseUrl}/${packageName}/edits?access_token=${token}`
@@ -27,23 +47,10 @@ exports.publish = async ({ keyFilePath, packageName, track, apkFilePath }) => {
     const { id: editId } = editRes;
 
     // upload apk
-    const apk = await readFilePromise(apkFilePath);
-    const { size } = fs.statSync(apkFilePath);
-    const uploadRes = await axios.post(
-      `${uploadUrl}/${packageName}/edits/${editId}/apks?uploadType=media&access_token=${token}`,
-      apk,
-      {
-        headers: {
-          Connection: 'keep-alive',
-          'accept-encoding': 'gzip, deflate',
-          Accept: '*/*',
-          'Content-Type': 'application/vnd.android.package-archive',
-          Authorization: token
-        },
-        maxContentLength: size * 1000,
-        maxBodyLength: size * 1000
-      }
-    );
+    const file = await readFilePromise(filePath);
+    const { size } = fs.statSync(filePath);
+
+    const uploadRes = await upload(packageName, editId, file, fileType, size, token)
     const { versionCode } = uploadRes.data;
 
     // set track
@@ -73,3 +80,11 @@ exports.publish = async ({ keyFilePath, packageName, track, apkFilePath }) => {
     throw e.response.data.error;
   }
 };
+
+exports.publishAPK = async ({ keyFilePath, packageName, track, filePath }) => {
+  return await publish(keyFilePath, packageName, track, filePath, "apks")
+}
+
+exports.publishAAB = async ({ keyFilePath, packageName, track, filePath }) => {
+  return await publish(keyFilePath, packageName, track, filePath, "bundles")
+}

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
       published: true
     };
   } catch (e) {
-    throw e.response.data.error;
+    throw e
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ const fs = require('fs');
 const util = require('util');
 const readFilePromise = util.promisify(fs.readFile);
 
+const APK  = "apks"
+const AAB = "bundles"
+
 const getAuth = keyFilePath =>
   google.auth.getClient({
     keyFile: keyFilePath,
@@ -13,6 +16,13 @@ const getAuth = keyFilePath =>
 
 upload = async ({ packageName, editId, file, fileType, size, token }) => {
   const uploadUrl = 'https://www.googleapis.com/upload/androidpublisher/v3/applications';
+  let contentType;
+
+  if (fileType == APK) {
+    contentType = 'application/vnd.android.package-archive'
+  } else if (fileType == AAB) {
+    contentType = 'application/octet-stream'
+  }
 
   return await axios.post(
     `${uploadUrl}/${packageName}/edits/${editId}/${fileType}?uploadType=media&access_token=${token}`,
@@ -22,7 +32,7 @@ upload = async ({ packageName, editId, file, fileType, size, token }) => {
         Connection: 'keep-alive',
         'accept-encoding': 'gzip, deflate',
         Accept: '*/*',
-        'Content-Type': 'application/vnd.android.package-archive',
+        'Content-Type': contentType,
         Authorization: token
       },
       maxContentLength: size * 1000,
@@ -83,9 +93,9 @@ publish = async ({ keyFilePath, packageName, track, filePath, fileType }) => {
 };
 
 exports.publishAPK = async ({ keyFilePath, packageName, track, filePath }) => {
-  return await publish({ keyFilePath: keyFilePath, packageName: packageName, track: track, filePath: filePath, fileType: "apks" })
+  return await publish({ keyFilePath: keyFilePath, packageName: packageName, track: track, filePath: filePath, fileType: APK })
 }
 
 exports.publishAAB = async ({ keyFilePath, packageName, track, filePath }) => {
-  return await publish({ keyFilePath: keyFilePath, packageName: packageName, track: track, filePath: filePath, fileType: "bundles" })
+  return await publish({ keyFilePath: keyFilePath, packageName: packageName, track: track, filePath: filePath, fileType: AAB })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-playstore-publisher",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "Publish your app to google playstore using publisher api https://developers.google.com/android-publisher/#publishing",
   "main": "index.js",
   "scripts": {
@@ -24,8 +24,8 @@
   "author": "Yogesh Lakhotia",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.18.0",
-    "googleapis": "^39.2.0",
+    "axios": "^0.21.1",
+    "googleapis": "^84.0.0",
     "yargs": "^13.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
**- BREAKING CHANGE -**

As of August 2021 Google requires that developers upload apps via the new .aab (Android App Bundle) format.  
  - https://android-developers.googleblog.com/2020/11/new-android-app-bundle-and-target-api.html

This PR adds support for the new .aab format while maintaining support for the now deprecated .apk format.  To improve the CLI experience changes needed to be made to better reflect the options provided as well as their aliases.  As such, the changes will break existing scripts.  To honor this, the major version has been ticked to 2.